### PR TITLE
Fix: Follow infinity api url format

### DIFF
--- a/litellm/llms/infinity/rerank/transformation.py
+++ b/litellm/llms/infinity/rerank/transformation.py
@@ -20,6 +20,13 @@ from .common_utils import InfinityError
 
 
 class InfinityRerankConfig(CohereRerankConfig):
+    def get_complete_url(self, api_base: str, model: str) -> str:
+        # Remove trailing slashes and ensure clean base URL
+        api_base = api_base.rstrip("/")
+        if not api_base.endswith("/rerank"):
+            api_base = f"{api_base}/rerank"
+        return api_base
+        
     def validate_environment(
         self,
         headers: dict,


### PR DESCRIPTION
## Title
Follow infinity api url format

## Relevant issues
Infinity rerank API format is `api_base + /rerank` instead of `api_base + /v1/rerank`
![image](https://github.com/user-attachments/assets/99cf180f-8c5a-431e-b940-87746f3bd7ef)


## Type
🐛 Bug Fix


